### PR TITLE
Fix the `Source Code` link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -134,7 +134,7 @@ pluralizeListTitles = false
   [[languages.en.menu.footer]]
     identifier = "source"
     name       = "Source Code"
-    url        = "/source"
+    url        = "https://github.com/uradotdesign/ura.design"
     weight     = "1"
   [[languages.en.menu.footer]]
     identifier = "privacy-policy"


### PR DESCRIPTION
Hi,

I've been casually browsing your site and noticed that the "Source Code" link is broken.

I'm not sure if this fix is exactly what you'd like to see but I figured out there's no harm in just sending it.

Btw, I've also not tested it :sweat_smile: 

Have a nice day! :wave: